### PR TITLE
Adding Back Twitter and helping Safari work

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -3,9 +3,9 @@ global:
   short_name: IML
   mode: CNCF
   repo: cncf/mobility_landscape
-  website: 'https://landscape.cncf.io'
+  website: 'https://nrel.github.io/mobility_landscape/'
   short_domain: l.cncf.io
-  company_url: 'https://www.cncf.io'
+  company_url: 'https://www.nrel.gov/index.html'
   email: k.shankari@nrel.gov
   self: 'https://www.crunchbase.com/organization/cloud-native-computing-foundation'
   slack_channel: T08PSQ7BQ/BC07DVB0C/jqc0ANnvpVddAp651jgyMKdr
@@ -141,7 +141,7 @@ big_picture:
     name: Landscape
     short_name: Land...
     title: Interactive Mobility Landscape
-    fullscreen_header: Overwhelmed? Please see the CNCF Trail Map. That and the interactive landscape are at l.cncf.io
+    fullscreen_header: Overwhelmed? Please see the Trail Map.
     elements:
       - type: VerticalCategory
         category: Infrastructure
@@ -210,11 +210,11 @@ big_picture:
 
 test:
   header: Interactive Mobility Landscape
-  section: CNCF Graduated Projects
+  section: Graduated Projects
   logo: kubernetes.svg
 anonymous_organization:
   name: Non-Public Unnamed Organization
-  homepage: 'https://www.cncf.io'
+  homepage: 'https://nrel.github.io/mobility_landscape/'
   city: Bouvet Island
   region: Antarctica
   country: Antarctica

--- a/settings.yml
+++ b/settings.yml
@@ -3,21 +3,29 @@ global:
   short_name: IML
   mode: CNCF
   repo: cncf/mobility_landscape
-  website: 'https://nrel.github.io/mobility_landscape/'
-  company_url: 'https://www.nrel.gov/index.html'
-  email: k.shankari@nrel.gov
+  website: 'https://landscape.cncf.io'
+  short_domain: l.cncf.io
+  company_url: 'https://www.cncf.io'
+  email: info@cncf.io
+  self: 'https://www.crunchbase.com/organization/cloud-native-computing-foundation'
+  slack_channel: T08PSQ7BQ/BC07DVB0C/jqc0ANnvpVddAp651jgyMKdr
   meta:
     title: Interactive Mobility Landscape
     fb_admin: alex.contini.94
     description: 'Filter and sort by GitHub stars, funding, commits, contributors, hq location, and tweets'
+    twitter: '@CloudNativeFdn'
     google_site_verification: 8l35EQriJXntsib5sBdRu4gmDV1nAP9PSoHccJC8ABQ
     ms_validate: 3AF9FFA12CCC3C49C0ABA71CCA222665
   flags:
     hide_license_for_categories:
       - Special
-      - Members
+      - CNCF Members
     hide_category_from_subcategories:
       - End User Supporter
+twitter:
+  search: landscape.cncf.io
+  url: 'https://landscape.cncf.io'
+  text: Cloud Native Landscape from @CloudNativefdn
 relation:
   label: CNCF Relation
   url: cncf
@@ -133,13 +141,13 @@ big_picture:
     name: Landscape
     short_name: Land...
     title: Interactive Mobility Landscape
-    fullscreen_header: Overwhelmed? Please see the Trail Map. 
+    fullscreen_header: Overwhelmed? Please see the CNCF Trail Map. That and the interactive landscape are at l.cncf.io
     elements:
       - type: VerticalCategory
         category: Infrastructure
         cols: 9
         width: 275
-        height: 1200
+        height: 1700
         top: 350
         left: 0
         color: 'rgb(109,61,143)'
@@ -147,7 +155,7 @@ big_picture:
         category: Vehicles
         cols: 9
         width: 275
-        height: 1000
+        height: 1600
         top: 350
         left: 350
         color: 'rgb(46,107,46)'
@@ -155,7 +163,7 @@ big_picture:
         category: People
         cols: 9
         width: 275
-        height: 400
+        height: 600
         top: 350
         left: 700
         color: 'rgb(143,88,61)'
@@ -199,13 +207,14 @@ big_picture:
             left: 15
             top: 15
             title: Landscape Logo
+
 test:
   header: Interactive Mobility Landscape
-  section: Graduated Projects
+  section: CNCF Graduated Projects
   logo: kubernetes.svg
 anonymous_organization:
   name: Non-Public Unnamed Organization
-  homepage: 'https://nrel.github.io/mobility_landscape/'
+  homepage: 'https://www.cncf.io'
   city: Bouvet Island
   region: Antarctica
   country: Antarctica

--- a/settings.yml
+++ b/settings.yml
@@ -6,7 +6,7 @@ global:
   website: 'https://landscape.cncf.io'
   short_domain: l.cncf.io
   company_url: 'https://www.cncf.io'
-  email: info@cncf.io
+  email: k.shankari@nrel.gov
   self: 'https://www.crunchbase.com/organization/cloud-native-computing-foundation'
   slack_channel: T08PSQ7BQ/BC07DVB0C/jqc0ANnvpVddAp651jgyMKdr
   meta:

--- a/settings.yml
+++ b/settings.yml
@@ -4,7 +4,6 @@ global:
   mode: CNCF
   repo: cncf/mobility_landscape
   website: 'https://nrel.github.io/mobility_landscape/'
-  short_domain: l.cncf.io
   company_url: 'https://www.nrel.gov/index.html'
   email: k.shankari@nrel.gov
   meta:

--- a/settings.yml
+++ b/settings.yml
@@ -7,8 +7,6 @@ global:
   short_domain: l.cncf.io
   company_url: 'https://www.nrel.gov/index.html'
   email: k.shankari@nrel.gov
-  self: 'https://www.crunchbase.com/organization/cloud-native-computing-foundation'
-  slack_channel: T08PSQ7BQ/BC07DVB0C/jqc0ANnvpVddAp651jgyMKdr
   meta:
     title: Interactive Mobility Landscape
     fb_admin: alex.contini.94
@@ -19,7 +17,7 @@ global:
   flags:
     hide_license_for_categories:
       - Special
-      - CNCF Members
+      - Members
     hide_category_from_subcategories:
       - End User Supporter
 twitter:
@@ -141,7 +139,7 @@ big_picture:
     name: Landscape
     short_name: Land...
     title: Interactive Mobility Landscape
-    fullscreen_header: Overwhelmed? Please see the Trail Map.
+    fullscreen_header: Overwhelmed? Please see the Trail Map. 
     elements:
       - type: VerticalCategory
         category: Infrastructure
@@ -207,7 +205,6 @@ big_picture:
             left: 15
             top: 15
             title: Landscape Logo
-
 test:
   header: Interactive Mobility Landscape
   section: Graduated Projects


### PR DESCRIPTION
These changes put back in a lot of the CNCF removal that was originally in place, as well as adding back twitter to ensure that it works. As well, changes made to the vertical categories to help the safari browser were left in.
