### PR TITLE
Add a GHA which builds the landscape on every PR

### DIFF
--- a/.github/workflows/create_pr_preview.yml
+++ b/.github/workflows/create_pr_preview.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     env: 
       PROJECT_PATH: "../landscape"
+      SKIP_VERSION_CHECK: 1
     # We run only on macos here since the repo2docker tests will run on ubuntu
     runs-on: ubuntu-latest
 

--- a/.github/workflows/create_pr_preview.yml
+++ b/.github/workflows/create_pr_preview.yml
@@ -9,7 +9,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build-and-publish:
+  build-and-publish-image-artifacts:
     env: 
       PROJECT_PATH: "../landscape"
       SKIP_VERSION_CHECK: 1

--- a/.github/workflows/create_pr_preview.yml
+++ b/.github/workflows/create_pr_preview.yml
@@ -1,4 +1,4 @@
-name: exploratory-notebook-test-osx
+name: create_pr_preview
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
@@ -20,12 +20,14 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Check out the landscape version in the PR
       uses: actions/checkout@v2
-      path: 'landscape'
+      with:
+        path: 'landscape'
 
     - name: Check out the most recent version of the landscapeapp
       uses: actions/checkout@v2
-      repository: 'https://github.com/NREL/mobility_landscapeapp.git'
-      path: 'landscapeapp'
+      with:
+        repository: 'https://github.com/NREL/mobility_landscapeapp.git'
+        path: 'landscapeapp'
 
     - name: Install the landscapeapp dependencies
       run: |

--- a/.github/workflows/create_pr_preview.yml
+++ b/.github/workflows/create_pr_preview.yml
@@ -1,0 +1,58 @@
+name: exploratory-notebook-test-osx
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    env: 
+      PROJECT_PATH: "../landscape"
+    # We run only on macos here since the repo2docker tests will run on ubuntu
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Check out the landscape version in the PR
+      uses: actions/checkout@v2
+      path: 'landscape'
+
+    - name: Check out the most recent version of the landscapeapp
+      uses: actions/checkout@v2
+      repository: 'https://github.com/NREL/mobility_landscapeapp.git'
+      path: 'landscapeapp'
+
+    - name: Install the landscapeapp dependencies
+      run: |
+        cd landscapeapp
+        npm install yarn
+        yarn
+
+    - name: Build and generate previews
+      run: |
+        npx yarn build-only
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - name: Upload the image file as a build artifact for the user to check
+      uses: actions/upload-artifact@v1
+      if: success()
+      with:
+        name: landscape.png
+        path: ./dist/mobility_landscape/images/landscape.png
+
+    - name: Upload the pdf preview a build artifact for the user to check
+      uses: actions/upload-artifact@v1
+      if: success()
+      with:
+        name: landscape.pdf
+        path: ./dist/mobility_landscape/images/landscape.pdf

--- a/.github/workflows/create_pr_preview.yml
+++ b/.github/workflows/create_pr_preview.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Check out the most recent version of the landscapeapp
       uses: actions/checkout@v2
       with:
-        repository: 'https://github.com/NREL/mobility_landscapeapp.git'
+        repository: 'NREL/mobility_landscapeapp'
         path: 'landscapeapp'
 
     - name: Install the landscapeapp dependencies

--- a/.github/workflows/create_pr_preview.yml
+++ b/.github/workflows/create_pr_preview.yml
@@ -37,6 +37,7 @@ jobs:
 
     - name: Build and generate previews
       run: |
+        cd landscapeapp
         npx yarn build-only
 
   publish:
@@ -50,11 +51,11 @@ jobs:
       if: success()
       with:
         name: landscape.png
-        path: ./dist/mobility_landscape/images/landscape.png
+        path: ./landscape/dist/mobility_landscape/images/landscape.png
 
     - name: Upload the pdf preview a build artifact for the user to check
       uses: actions/upload-artifact@v1
       if: success()
       with:
         name: landscape.pdf
-        path: ./dist/mobility_landscape/images/landscape.pdf
+        path: ./landscape/dist/mobility_landscape/images/landscape.pdf

--- a/.github/workflows/create_pr_preview.yml
+++ b/.github/workflows/create_pr_preview.yml
@@ -9,7 +9,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  build-and-publish:
     env: 
       PROJECT_PATH: "../landscape"
       SKIP_VERSION_CHECK: 1
@@ -41,12 +41,6 @@ jobs:
         cd landscapeapp
         npx yarn build-only
 
-  publish:
-    needs: build
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
     - name: Upload the image file as a build artifact for the user to check
       uses: actions/upload-artifact@v1
       if: success()

--- a/.github/workflows/publish_gh_pages.yml
+++ b/.github/workflows/publish_gh_pages.yml
@@ -1,17 +1,15 @@
-name: create_pr_preview
+name: publish_gh_pages
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build-and-publish:
+  build-and-publish-to-gh-pages:
     env: 
       PROJECT_PATH: "../landscape"
       SKIP_VERSION_CHECK: 1

--- a/.github/workflows/publish_gh_pages.yml
+++ b/.github/workflows/publish_gh_pages.yml
@@ -1,0 +1,54 @@
+name: create_pr_preview
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build-and-publish:
+    env: 
+      PROJECT_PATH: "../landscape"
+      SKIP_VERSION_CHECK: 1
+    # We run only on macos here since the repo2docker tests will run on ubuntu
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Check out the landscape version in the PR
+      uses: actions/checkout@v2
+      with:
+        path: 'landscape'
+
+    - name: Check out the most recent version of the landscapeapp
+      uses: actions/checkout@v2
+      with:
+        repository: 'NREL/mobility_landscapeapp'
+        path: 'landscapeapp'
+
+    - name: Install the landscapeapp dependencies
+      run: |
+        cd landscapeapp
+        npm install yarn
+        yarn
+
+    - name: Build and generate previews
+      run: |
+        cd landscapeapp
+        npx yarn build-only
+
+    - name: Publish to the gh-pages branch
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./landscape/dist/mobility_landscape
+        force_orphan: true
+        user_name: 'github-actions[bot]'
+        user_email: 'github-actions[bot]@users.noreply.github.com'
+        commit_message: ${{ github.event.head_commit.message }}


### PR DESCRIPTION
And copies out the image and pdf for preview

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~15 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
