### PR TITLE
Move NREL tags to beginning

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -34,7 +34,7 @@ relation:
         - id: NREL
           label: NREL Projects
           prefix: NREL
-          big_picture_order: 
+          big_picture_order: 1
           big_picture_label: NREL Project
           big_picture_color: 'rgb(0,121,194)'
     - id: member


### PR DESCRIPTION
I did not assign a big_picture_order value to the NREL, which is why they aren't showing up at the beginning. No need to change landscape app.